### PR TITLE
Update lesson.yaml

### DIFF
--- a/Matrices_et_Dataframes/lesson.yaml
+++ b/Matrices_et_Dataframes/lesson.yaml
@@ -223,7 +223,7 @@
   Output: "Puisque nous avons 6 colonnes (incluant les noms des patients), nous devons tout d'abord créer un vecteur, que nous appellerons cnames contenant ces valeurs (dans l'ordre): patient, age, weight, bp, rating et test."
   CorrectAnswer: cnames = c("patient", "age", "weight", "bp", "rating", "test")
   AnswerTests: omnitest(correctExpr='cnames = c("patient", "age", "weight", "bp", "rating", "test")')
-  Hint: "Assurez-vous que chaque mot soit en minuscule, entre guillemets (et sans espace à l'intérieur des guillemets), et séparés par des virgules. N'oubliez pas de mettre tout ça dans un vecteur avec la fonction c() et d'affectez tout ça a une variable cnames."
+  Hint: "Assurez-vous que chaque mot soit en minuscules, entre guillemets (et sans espace à l'intérieur des guillemets), et séparés par des virgules. N'oubliez pas de mettre tout ça dans un vecteur avec la fonction c() et d'affectez tout ça a une variable cnames."
 
 # Q34
 - Class: cmd_question


### PR DESCRIPTION
Concernant les matrices, je trouve qu'il manque 
1) une question du genre : Affichons seulement l'élément ligne 2 et colonne 4 de my_matrix en tapant
my_matrix[ 2,4 ]
2) une question du genre : Affichons seulement les colonnes 2 et 4 de my_matrix en tapant
my_matrix[ , c(2,4) ]
puis à la question suivante : Affichez la 1ère et 3ème lignes de la matrice my_matrix
(peut-être est-ce aborder plus tard ?).
3) une question pour remarquer  l'ordre de remplissage par défaut byrow=FALSE
quand il s'agit de données en colonnes cela paraît naturel de remplir en colonnes mais quand il s'agit d'une matrice d'un système linéaire, on remplit naturellement de gauche à droite et de haut vers bas comme pour l'ordre de la lecture.
J'ajouterai une question Q17bis du genre : tapez
my_matrix2 = matrix(1:20, nrow=4, ncol=5,byrow=TRUE)
La différence avec la commande précédente est l'orde de remplissage de la matrice (ligne se dit row en anglais)